### PR TITLE
Fixing "URL:" selectors without preceding slash

### DIFF
--- a/pygopherd/handlers/UMN.py
+++ b/pygopherd/handlers/UMN.py
@@ -209,7 +209,7 @@ class UMNDirHandler(DirHandler):
                     # Handle ./: make full path.
                     entry.setselector(self.selectorbase + "/" + pathname[2:])
                     entry.setneedsmerge(1)
-                elif len(pathname) and pathname[0] != '/':
+                elif len(pathname) and pathname[0] != '/' and pathname[0:4] != "URL:":
                     entry.setselector(pathname)
                     entry.setneedsabspath(1)
                 else:

--- a/pygopherd/handlers/gophermap.py
+++ b/pygopherd/handlers/gophermap.py
@@ -71,7 +71,7 @@ class BuckGophermapHandler(base.BaseHandler):
                     args[1] = args[0][1:] # Copy display string to selector
 
                 selector = args[1]
-                if selector[0] != '/': # Relative link
+                if selector[0] != '/' and selector[0:4] != "URL:": # Relative link
                     selector = selectorbase + '/' + selector
                 
                 entry = gopherentry.GopherEntry(selector, self.config)


### PR DESCRIPTION
Due to a quirk in how the gophermap and umn handlers work, "URL:" selectors in subdirectories require a preceding slash to not be interpreted as relative links. This fix makes the handlers in question treat "URL:" selectors the same as absolute links.